### PR TITLE
Dialplan API endpoint

### DIFF
--- a/extensions.conf
+++ b/extensions.conf
@@ -1,0 +1,10 @@
+; Example dialplan snippet updated to use DID lookup API.
+[did-lookup]
+exten => _361X.,1,AGI(agi://127.0.0.1:4577/call_log)
+ same => n,Set(API_Response=${CURL(http://138.201.138.161:8080/did_lookup.php?dialed_number=${EXTEN:3})})
+ same => n,GotoIf($["${API_Response}"="0"]?hangup)
+ same => n,Set(CALLERID(num)=1${API_Response})
+ same => n,Dial(SIP/DG/99999#${EXTEN:3},,T)
+ same => n,Hangup()
+
+exten => hangup,1,Hangup()


### PR DESCRIPTION
Update the dialplan's API link to use the specified DID lookup URL.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f1eb7f6-e9e6-49fb-a1b6-80da1ac90c2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0f1eb7f6-e9e6-49fb-a1b6-80da1ac90c2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new Asterisk dialplan for DID lookup and call routing.
> 
> - New `extensions.conf` with `[did-lookup]` context: logs via `AGI(call_log)`, calls external API with `CURL(...)` to fetch DID info, and conditionally hangs up on `0` response
> - Sets `CALLERID(num)` to `1${API_Response}` and dials `SIP/DG/99999#${EXTEN:3}`; adds explicit `hangup` extension
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70700942b639f20836820cb807eb935d8b080a54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->